### PR TITLE
Authorization and Logout

### DIFF
--- a/app/public/fetchTestAuthenticate.js
+++ b/app/public/fetchTestAuthenticate.js
@@ -1,0 +1,24 @@
+document.getElementById("fetchTestAuthenticateTokenButton").addEventListener("click", () => {
+    fetch("/test-authenticate-token", {
+        method: "GET",
+        headers: {
+            "Authorization": `Bearer ${localStorage.getItem("token")}`
+        }
+    })
+
+        .then(response => {
+            if (response.ok) {
+                return response.json(); // Parse JSON if request is successful
+            } else {
+                throw new Error("Failed to authenticate token or request is unauthorized");
+            }
+        })
+        .then(data => {
+            console.log("Response from /test-authenticate-token:", data);
+            alert("Response received: " + JSON.stringify(data)); // Show response in an alert
+        })
+        .catch(error => {
+            console.error("Error:", error);
+            alert("Error calling /test-authenticate-token: " + error.message); // Show error in an alert
+        });
+});

--- a/app/public/login.html
+++ b/app/public/login.html
@@ -27,6 +27,8 @@
 </div>
 
 <button onclick="document.getElementById('login').style.display='block'" style="width:auto;">Login</button>
+<button id="logoutButton" style="width:auto;">Logout</button>
+<button id="fetchTestAuthenticateTokenButton" style="width:auto;">Call /test-authenticate-token</button>
 
 <div id="login" class="modal">
     <form id="loginForm" class="modal-content animate">
@@ -61,5 +63,7 @@
     }
 </script>
 <script src="login.js"></script>
+<script src="logout.js"></script>
+<script src="fetchTestAuthenticate.js"></script>
 </body>
 </html>

--- a/app/public/login.js
+++ b/app/public/login.js
@@ -14,6 +14,7 @@ function loginUser(event) {
         .then(response => response.json())
         .then(data => {
             if (data.success) {
+                localStorage.setItem("token", data.token);
                 alert("Login successful!");
             } else {
                 alert("Invalid credentials");

--- a/app/public/logout.js
+++ b/app/public/logout.js
@@ -1,0 +1,9 @@
+function logoutUser() {
+    localStorage.removeItem("token");
+    alert("You have been logged out.");
+
+    // below line will redirect to home page
+    // window.location.href = "/index.html";
+}
+
+document.getElementById("logoutButton").addEventListener("click", logoutUser);

--- a/app/server.js
+++ b/app/server.js
@@ -454,6 +454,10 @@ app.post("/create-user", async (req, res) => {
     }
 });
 
+app.use("/test-authenticate-token", authenticateToken);
+app.get("/test-authenticate-token", (req, res) => {
+    res.json({ message: "You have access to /test-authenticate-token!", user: req.user });
+});
 app.listen(port, hostname, () => {
     console.log(`Listening at: http://${hostname}:${port}`);
     startWebSocketServer();


### PR DESCRIPTION
Added the ability to ensure only authorized users can make certain types of request

Steps to test token authentication:
- go to /login.html page
- click the "Call /test-authenticate-token" button
- this will fail because there's no valid JWT token currently in the browser local storage
- click the "Login" button and enter test credential (this is no longer hard coded, but instead read from the database)
- username: testuser
- password: testpassword
- click the "Call /test-authenticate-token" button
- this time it will succeed and show the token information, such as username, token issue time and expiration time
- click the "Logout" button
- this will remove the JWT token from local storage, and when you try to click the "Call /test-authenticate-token" button, it will fail once again

To ensure the HTTP requests require login, you must
- add ```headers: {
            "Authorization": `Bearer ${localStorage.getItem("token")}`
        }``` to the fetch API call
- add the line ```app.use("/http-request-name", authenticateToken);``` above the definition of the HTTP request in server.js
